### PR TITLE
Bump minimum requirement to at least 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installs osquery
 Requirements
 ------------
 
-This role requires Ansible 1.9 or higher.
+This role requires Ansible 2.0 or higher.
 
 Role Variables
 --------------


### PR DESCRIPTION
Blocks were a feature only introduced in 2.0. 

See:
  - https://github.com/juju4/ansible-osquery/blame/master/tasks/configure.yml#L6
  - http://docs.ansible.com/ansible/latest/playbooks_blocks.html