### PR TITLE
Define the auditd_pkg such that it can be verified against

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -79,7 +79,7 @@
 ## https://osquery.readthedocs.io/en/stable/deployment/process-auditing/
 - block:
     - name: ensure auditd is not present
-      package: name={{ auditd_pkg }} state=absent
+      package: name="{{ _osquery_auditd_pkg }}" state=absent
   when: osquery_process_auditing
 
 - name: get rsyslog version

--- a/vars/CentOS-6.yml
+++ b/vars/CentOS-6.yml
@@ -1,1 +1,2 @@
 ---
+_osquery_auditd_pkg: "audit"

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -1,1 +1,2 @@
 ---
+_osquery_auditd_pkg: "audit"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -11,3 +11,5 @@ osquery_debug_packages:
 
 _osquery_repository: "{{ osquery_repository | default('https://pkg.osquery.io/rpm/osquery-s3-rpm.repo') }}"
 _osquery_repositorykey: "{{ osquery_repositorykey | default('https://pkg.osquery.io/rpm/GPG') }}"
+
+_osquery_auditd_pkg: "audit"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -12,3 +12,5 @@ osquery_debug_packages:
 
 _osquery_repository: "{{ osquery_repository | default('deb [arch=amd64] https://pkg.osquery.io/deb deb main') }}"
 _osquery_repositorykey: "{{ osquery_repositorykey | default('1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B') }}"
+
+_osquery_auditd_pkg: "auditd"

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,1 +1,2 @@
 ---
+_osquery_auditd_pkg: "audit"

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,1 +1,2 @@
 ---
+_osquery_auditd_pkg: "audit"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -11,3 +11,5 @@ osquery_debug_packages:
 
 _osquery_repository: "{{ osquery_repository | default('https://pkg.osquery.io/rpm/osquery-s3-rpm.repo') }}"
 _osquery_repositorykey: "{{ osquery_repositorykey | default('https://pkg.osquery.io/rpm/GPG') }}"
+
+_osquery_auditd_pkg: "audit"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -10,3 +10,5 @@ osquery_debug_packages:
 
 _osquery_repository: "{{ osquery_repository | default('deb [arch=amd64] https://pkg.osquery.io/deb deb main') }}"
 _osquery_repositorykey: "{{ osquery_repositorykey | default('1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B') }}"
+
+_osquery_auditd_pkg: "auditd"


### PR DESCRIPTION
Currently thehre is a bug in which if process auditing is enabled,
auditd will be disabled. However, the variable in which auditd should be
defined is not present.

This commit adds packages to each OS Variables file, based on a cursory
review of the relevant package repos.

It has not been tested.