### PR TITLE
AD-HOC fix (ansible_managed): Allow multiline ansible_managed

### DIFF
--- a/templates/logrotate-osquery.j2
+++ b/templates/logrotate-osquery.j2
@@ -1,4 +1,4 @@
-## {{ ansible_managed }}
+{{ ansible_managed | comment('plain', decoration='## ') }}
 ## /etc/logrotate.d/osquery
 /var/log/osquery/osqueryd.results.log {
     rotate {{ osquery_logrotate_days|int }}

--- a/templates/osquery.conf.j2
+++ b/templates/osquery.conf.j2
@@ -1,4 +1,4 @@
-// {{ ansible_managed }}
+{{ ansible_managed | comment('c')}}
 {
   // Configure the daemon below:
   "options": {

--- a/templates/osqueryd-monit.j2
+++ b/templates/osqueryd-monit.j2
@@ -1,4 +1,4 @@
-## {{ ansible_managed }}
+{{ ansible_managed | comment('plain', decoration='## ') }}
 check process osqueryd
   with pidfile "/var/run/osqueryd.pid"
   group system


### PR DESCRIPTION
Ansible allows denoting files as "ansible_managed" by including a
specific string in the file. In the implemented repository, this
appeared as follows:

```
ansible_managed =
  This file is managed by Ansible. Changes to it will not be persisted and should be made instead to the development
  node repository. See:

    https://github.com/path/to/repo
```

This allows a more substantial help for those looking to make a change
permanent, particularly when Ansible is not yet the canonical mechanism
for managing change across all systems in a fleet.

Currently there is a bug in these roles in which if the ansible_managed
string is multiline, it will not be commented out in the particular
files in which it's inserted. Instead, only the first line is commented
out.

This commit resolves that by using the comment filter supplied since
Ansible 2.0 to ensure this content is commented out, rather than simply
prefixing the line with '##' (or another related character).

== Design Notes ==

=== Use of specific decorator ===

This commit attempts to preserve the pattern of double #'ing comments by
supplying the decorator (comment prefix) of '## '.