### PR TITLE
AD-HOC feat (Configuration): Support expressing an OSQuery secret

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,8 +31,11 @@ osquery_flags: []
 ## if using zentral, kolide or else
 ## https://github.com/zentralopensource/zentral/blob/f460b10a95d4ea1e515aea3363f55733465d1d9c/zentral/contrib/osquery/deb_script/template.sh
 ## https://docs.kolide.co/kolide/current/infrastructure/adding-hosts-to-kolide.html
+
+#osquery_enroll_secret: ""
+
 #osquery_flags:
-#    - { re: '^--enroll_secret_env=.*', l: '--enroll_secret_env=OSQUERY_ENROLL_SECRET' }
+#    - { re: '^--enroll_secret_path=.*', l: '--enroll_secret_path=/etc/osquery/osquery_enroll_secret' }
 #    - { re: '^--tls_server_certs=.*', l: '--tls_server_certs=/etc/osquery/kolide.crt' }
 #    - { re: '^--tls_hostname=.*', l: '--tls_hostname=acme.kolide.co' }
 #    - { re: '^--host_identifier=.*', l: '--host_identifier=hostname' }

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,6 +29,22 @@
 #        validate: 'egrep -v '^\s*//' %s | tee /tmp/a | python -mjson.tool'
       notify:
         - restart osquery
+    - name: "ensure osquery var dir exists"
+      file:
+        state: "directory"
+        path: "/var/osquery"
+    - name: "express the osquery secret to disk"
+      lineinfile:
+        path: "/etc/osquery/osquery_enroll_secret"
+        regexp: '^'
+        line: ''
+        state: present
+        owner: "root"
+        group: "root"
+        mode: "0600"
+        create: true
+      when:
+        - osquery_enroll_secret is defined
     - name: configure osquery flags
       template:
         src: "osquery.flags.j2"


### PR DESCRIPTION
When registering OSQuery with a central server the server requires
either a shared secret to be expressed, or mutual TLS authentication.
This commit implements one such mechanism for managing this identity
verification.

== Design Notes ==

=== File over Environment ===

It's possible to express the secret both as an environment variable,
and as a file. The most common mechanisms for supplying environment
variables the author has used are:

- /etc/environment
- systemd extension

However, neither suits in this case. The playbook will be run against
non-systemd hosts, and /etc/environment is inherited by all processes.

Accordingly, a file seemed the best mechanism to express the secret in a
compatible way. Additionally, it appears to be used in the kolide
tests against OSQuery anyway.