### PR TITLE
AD-HOC fix (Secret Enrollment): Consume variable in lineinfile

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -37,7 +37,7 @@
       lineinfile:
         path: "/etc/osquery/osquery_enroll_secret"
         regexp: '^'
-        line: ''
+        line: '{{ osquery_enroll_secret }}'
         state: present
         owner: "root"
         group: "root"


### PR DESCRIPTION
In previous work secret enrollment by expressing the secret to disk was
added. However, there was a critical bug in which the only secret
expressed to disk was an empty string ('') and not the variable that
actually contained the secret.

This commit addresses that bug.